### PR TITLE
NLP: Emphasis Weighting

### DIFF
--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -59,7 +59,6 @@ class Movie < ActiveRecord::Base
       rescore_review.build_all(sentiment_analyzer)
       review[:rescore_review] = rescore_review.sentences
       summary << review
-      
     end
     update_attribute(:reviews, summary)
     update_attributes({sentiment: set_sentiment, stats: set_stats})

--- a/lib/modules/context.rb
+++ b/lib/modules/context.rb
@@ -3,14 +3,12 @@ require_relative 'utils'
 
 module Context
   CONTEXTS = {
-
     editing: {'editing' => 100, 'post' => 20, 'production' => 50, 'effects' => 70},
     sound: {'sound' => 100, 'music' => 100, 'surround' => 80, 'dolby' => 100, 'ears' => 20, 'audio' => 100, 'sounds' => 100, 'score' => 10},
     plot: {'story' => 100, 'plot' => 100, 'tale' => 30, 'narrative' => 80, 'characters' => 50, 'character' => 50, 'journey' => 30, 'narration' => 80, 'persona' => 20},
     dialog: {'dialog' => 100, 'lines' => 70, 'speech' => 100, 'discussion' => 80, 'conversation' => 80, 'language' => 70, 'spoken' => 90, 'delivery' => 50},
     cast: {'acting' => 100, 'cast' => 100, 'performance' => 90, 'portrayal' => 90, 'depiction' => 90, 'characterization' => 90, 'impersonation' => 90, 'role' => 70, 'persona' => 50},
     vision: {'visuals' => 100, 'vision' => 90, 'imax' => 100, 'lifelike' => 80, 'screen' => 70, 'cgi' => 100, '3d' => 100, 'graphics' => 100, 'blurry' => 80, 'visual' => 100, 'eyes' => 30, 'spectacle' => 60, 'beautiful' => 20, 'graphic' => 90, 'colour' => 90, 'color' => 90, 'designs' => 8}
-
   }
 
   def Context.tag_sentence(sentence)

--- a/lib/rescore_review.rb
+++ b/lib/rescore_review.rb
@@ -15,6 +15,7 @@ class RescoreReview
       sentence[:sentiment] = sentiment_analyzer.get_sentiment(sentence[:clean_text])
       sentence[:context_tags] = Context.tag_sentence(sentence[:clean_text])
       sentence[:emphasis] = Emphasis.score(sentence[:text])
+
       next if @related_people.nil?
       people = People.tag_sentence(sentence[:text], @related_people, previous_name)
       sentence[:people_tags], previous_name, sentence[:people_indexes] = people


### PR DESCRIPTION
I looked around the emphasis module:
Emphasis score is now added to the overall score (score). 
The regex for caps emphasis is modified to all-caps words only. 
Question count now counts up question marks in the sentence rather than words containing qmarks and adds score to the emphasis score: 1 for 1 qmark, 2 for 2, 3 for 3 OR MORE qmarks.
Could do the same for exclamation marks, but it's not implemented yet.
