### PR TITLE
Count only complete movies on homepage

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
 
   def index
     @review_count = Statistic.find_by_identifier('review_count').value[:count]
-    @movie_count = Movie.count
+    @movie_count = Movie.complete_movies.size
     @movie = Movie.latest if Movie.latest.complete?
     @movie = Movie.first if !Movie.latest.complete?
   end


### PR DESCRIPTION
No point counting incomplete movies for users, since they can't access any info about them anyway.
