### PR TITLE
Update stats when movies saved and destroyed

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -100,7 +100,7 @@ class MoviesController < ApplicationController
   end
 
   def destroy
-    Movie.find(params[:id]).delete
+    Movie.find(params[:id]).destroy
     redirect_to movie_admin_path
   end
 

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -10,7 +10,8 @@ class Movie < ActiveRecord::Base
 
   before_save :default_values
   before_validation :set_slug if :title_changed?
-  after_destroy { Statistic.refresh }
+  after_destroy { Statistic.delay.refresh }
+  after_save { Statistic.delay.refresh }
 
   def set_slug
     self.slug = self.title.parameterize


### PR DESCRIPTION
Not sure why, but the after_destroy callback doesn't result in updated statistics on the "/stats" page.

The movie count goes down correctly, but the other two stats (reviews, people) stay the same.

(Adding a new movie updates them all fine).
