### PR TITLE
Set index logo max-width to 100% 

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -49,7 +49,7 @@ nav.top-bar {
 .large-logo {
   display: block;
   max-height: 200px;
-  max-width:  600px;
+  max-width:  100%;
   margin-top: 100px;
   margin-right: auto;
   margin-left: auto;


### PR DESCRIPTION
made an amendment to css to the large logo on the index page does not go off page when screen is resized 
